### PR TITLE
add support for text/paperscript

### DIFF
--- a/Syntaxes/HTML.plist
+++ b/Syntaxes/HTML.plist
@@ -3093,6 +3093,7 @@
 																  | livescript
 																  | (x-)?ecmascript
 																  | babel						# Javascript variant currently
+																  | paperscript						# paper.js's javascript variant
 																  								#   recognized as such
 															  	)
 															  | application/					# Application mime-types


### PR DESCRIPTION
text/paperscript is a type of javacript used by paper.js
http://paperjs.org/